### PR TITLE
NFS Server Docker Image Setup

### DIFF
--- a/.github/workflows/001-build-and-push-gcr.yaml
+++ b/.github/workflows/001-build-and-push-gcr.yaml
@@ -1,0 +1,62 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Get Version
+        id: get_version
+        run: |
+          if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
+            VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+            echo "version=$VERSION" >> $GITHUB_OUTPUT
+          else:
+            echo "version=latest" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+            registry: ghcr.io
+            username: ${{ github.repository_owner }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/nfs-server-docker
+          tags: |
+            type=raw,value=${{ steps.get_version.outputs.version }}
+            type=sha
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        id: build-push
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' && steps.get_version.outputs.version != 'latest' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/001-create-tag.yaml
+++ b/.github/workflows/001-create-tag.yaml
@@ -1,0 +1,36 @@
+name: Create Tag on Merge to Main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  create-tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+        contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get Next Tag
+        id: get_next_tag
+        run: |
+          #Get next semantic tag version
+          latest_tag=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || echo "v1.0.0")
+          major=$(echo $latest_tag | cut -d. -f1 | sed 's/v//')
+          minor=$(echo $latest_tag | cut -d. -f2)
+          patch=$(echo $latest_tag | cut -d. -f3)
+          new_patch=$((patch + 1))
+          next_tag="v${major}.${minor}.${new_patch}"
+          echo "next_tag=$next_tag" >> $GITHUB_OUTPUT
+
+      - name: Create Tag
+        run: |
+          git tag ${{ steps.get_next_tag.outputs.next_tag }}
+          git push origin ${{ steps.get_next_tag.outputs.next_tag }}

--- a/.github/workflows/002-create-release.yaml
+++ b/.github/workflows/002-create-release.yaml
@@ -1,0 +1,33 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Get tag name
+        id: get_tag
+        run: echo "tag_name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.get_tag.outputs.tag_name }}
+          name: Release ${{ steps.get_tag.outputs.tag_name }}
+          draft: false
+          prerelease: false
+          body: |
+            This is a release for version ${{ steps.get_tag.outputs.tag_name }} of the NFS server Docker image.
+
+            Changes:
+            - ... (List your changes) ...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:12
+
+ARG NFS_VERSION=1:2.6.2-4+deb12u1
+
+RUN set -x && \
+    apt update && apt install -qq -y openssl rpcbind nfs-common nfs-kernel-server=${NFS_VERSION}* && \
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir /exports
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +rx /usr/local/bin/docker-entrypoint.sh
+
+WORKDIR /exports
+
+VOLUME /exports
+
+EXPOSE 2049/tcp
+EXPOSE 20048/tcp
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s \
+  CMD exportfs -v || exit 1
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,68 @@
 # nfs-server-docker
+
+[![Build Status](https://github.com/majidmvulle/nfs-server-docker/actions/workflows/001-build-and-push-gcr.yaml/badge.svg)](https://github.com/majidmvulle/nfs-server-docker/actions/workflows/001-build-and-push-gcr.yaml)
+
+A simple Docker image for running an NFS server.  This image is based on Debian 12 and uses `nfs-kernel-server`.
+
+## Features
+
+*   Easy to set up and configure.
+*   Exports a directory (`/exports` by default) via NFS.
+*   Uses `rpcbind` and `nfs-kernel-server`.
+*   Healthcheck included to verify NFS server status.
+
+## Usage
+
+### Basic Usage
+
+```shell
+docker run --name nfs-server \
+    -v /path/to/your/data:/exports \
+    -p 2049:2049 -p 20048:20048 \
+    --cap-add SYS_ADMIN \
+    nfs-server-docker
+```
+
+### Docker Compose
+```shell
+version: "3.7"
+services:
+  nfs-server:
+    image: ghcr.io/majidmvulle/nfs-server-docker
+    volumes:
+      - /path/to/your/data:/exports
+    ports:
+      - "2049:2049"
+      - "20048:20048"
+    cap_add:
+      - SYS_ADMIN
+    restart: unless-stopped
+```
+
+### Building the Image Locally
+```shell
+docker build -t nfs-server-docker .
+```
+
+## Environment Variables
+* No custom environment variables are currently implemented, the default configuration is used, however, you could use a custom nfs version at build stage `--build-arg NFS_VERSION=1:2.6.2-4+deb12u1`, only nfs v4+ is supported.
+
+## Configuration
+The NFS server is configured using the standard `/etc/exports` file. Because you mount your data directory to `/exports` inside the container, the simplest way to configure exports is to create an exports file within your data directory on the host.
+
+**Example /path/to/your/data/exports file:**
+```shell
+/exports        10.0.0.0/24(rw,sync,no_subtree_check)
+/exports/subdir  10.0.0.10(rw,sync,no_subtree_check)
+```
+* `/exports:` The root directory being exported. 
+* `10.0.0.0/24:` The allowed client network CIDR range. 
+* `rw:` Read/write access. 
+* `sync:` Synchronous writes (recommended for data integrity). 
+* `no_subtree_check:` Disables subtree checking (often improves performance, but can have security implications in some cases). 
+* `/exports/subdir 10.0.0.10:` Example of exporting a subdirectory to a specific client IP address.
+
+**Note:** Make sure the permissions on your host directory (`/path/to/your/data`) and any subdirectories are set correctly for your NFS clients. You might need to adjust ownership and permissions using `chown` and `chmod`.
+
+## License
+This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+configure_exports() {
+  echo "[nfs-server] Configuring NFS exports..."
+  if [ ! -f /etc/exports ]; then
+    touch /etc/exports
+  fi
+
+  if [ -f "/exports/exports" ]; then
+    echo "[nfs-server] Using custom exports file from /exports/exports"
+    cat /exports/exports > /etc/exports
+  else
+    echo "[nfs-server] Using default exports (exporting /exports to all)"
+    echo "/exports *(rw,sync,no_subtree_check,no_root_squash)" > /etc/exports
+  fi
+
+  exportfs -ra
+}
+
+start_services() {
+  echo "[nfs-server] Starting rpcbind..."
+  /usr/sbin/rpcbind -w
+
+  echo "[nfs-server] Starting nfs-kernel-server..."
+  if command -v systemctl &> /dev/null; then
+    systemctl start nfs-kernel-server
+    systemctl enable nfs-kernel-server
+  elif command -v service &> /dev/null; then
+    service nfs-kernel-server start
+  else
+    echo "No init system detected"
+    exit 1
+  fi
+
+  # Keep the container running
+  tail -f /dev/null
+}
+
+configure_exports "$@"
+start_services


### PR DESCRIPTION
1.  **NFS Server Docker Image (`Dockerfile`, `docker-entrypoint.sh`):**
    *   **Base Image:** Uses Debian 12 as the base image.
    *   **NFS Components:** Installs `rpcbind`, `nfs-common`, and `nfs-kernel-server`.
    *   **Default Exports:** Configures `/exports` to be exported to all clients by default, but allows using a custom `/exports/exports` file if present.
    *   **Entrypoint Script (`docker-entrypoint.sh`):**
        *   Handles configuring the `/etc/exports` file.
        *   Starts `rpcbind`.
        *   Starts `nfs-kernel-server` using `systemctl` or `service`, depending on which is available.
        *   Keeps the container running with `tail -f /dev/null`.
    *   **Volume:** Defines `/exports` as a volume, allowing users to mount their data into the container.
    *   **Ports:** Exposes ports 2049 (NFS) and 20048 (mountd).
    *   **Healthcheck:** Includes a healthcheck using `exportfs -v` to verify that the NFS server is functioning.
    * **Capabilities** `SYS_ADMIN` cap is recommended for usage.

2.  **GitHub Actions Workflows:**
    *   **Create Tag (`001-create-tag.yaml`):**
        *   Triggers on merges to the `main` branch.
        *   Automatically creates a semantic version tag (e.g., `v1.0.1`, `v1.0.2`) based on the last tag in git.
        *   Pushes the tag to the remote repository.
    *   **Build and Push to GCR (`001-build-and-push-gcr.yaml`):**
        *   Triggers on pushes to `main` and tags `v*`, or manually.
        *   Builds the Docker image using `docker buildx`.
        *   Builds for `linux/amd64` and `linux/arm64` platforms.
        *   Pushes the image to GitHub Container Registry (ghcr.io).
        *   Tags the image with the tag version or `latest` for main branch pushes.
    *   **Create Release (`002-create-release.yaml`):**
        *   Triggers on pushes of tags `v*`.
        *   Creates a GitHub Release, associating it with the tag.
        *   Provides a default release description that can be modified.

3. **README.md**
    * provides documentation on how to use the nfs-server docker container.
    * Provides a default configuration option for nfs exports.
    * Provides basic usage examples for running the image with docker run, and docker-compose.

4. **Misc**
    * `.gitignore` used to ignore `DS_Store` and `idea` folders.