### PR TITLE
Improve GitHub Actions workflows

### DIFF
--- a/.github/workflows/002-build-and-push-gcr.yaml
+++ b/.github/workflows/002-build-and-push-gcr.yaml
@@ -5,10 +5,16 @@ on:
     workflows: ["Create Tag on Merge to Main"]
     types:
       - completed
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag version to use (e.g., v1.2.3)'
+        required: true
+        type: string
 
 jobs:
   build:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -24,20 +30,21 @@ jobs:
       - name: Get Version
         id: get_version
         run: |
-          if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then
-            VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
-          else:
-            echo "version=latest" >> $GITHUB_OUTPUT
+          # Triggered by workflow_run (tag creation from PR merge)
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            TAG_NAME=$(echo "${{ github.event.workflow_run.ref }}" | sed 's,refs/tags/,,' )
+            echo "version=$TAG_NAME" >> $GITHUB_OUTPUT
+          # Triggered by workflow_dispatch (manual build with specified tag)
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "version=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-            registry: ghcr.io
-            username: ${{ github.repository_owner }}
-            password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
@@ -46,7 +53,7 @@ jobs:
           images: ghcr.io/${{ github.repository_owner }}/nfs-server-docker
           tags: |
             type=raw,value=${{ steps.get_version.outputs.version }}
-            type=sha
+            type=sha,prefix=sha-
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -54,7 +61,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' && steps.get_version.outputs.version != 'latest' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
1.  **`workflow_dispatch` Trigger:**
    *   A `workflow_dispatch` trigger was added to the `on` section.
    *   This allows you to manually trigger the workflow from the GitHub Actions UI.
    *   It includes an `inputs` section with a `tag` field:
        *   `description`: Explains what the input is for.
        *   `required: true`: Makes this input mandatory when manually triggering.
        *   `type: string`: Specifies the input type.

2.  **`if` Condition for `build` Job:**
    *   The `if` condition for the `build` job was modified:
        ```yaml
        if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
        ```
    *   It now checks if:
        *   The triggering event is a `workflow_run` *and* its conclusion was `success` (meaning the "Create Tag on Merge to Main" workflow completed successfully).
        *   *Or* the triggering event is `workflow_dispatch` (meaning it was manually triggered).
    *   This ensures the job runs in both cases.

3.  **`Get Version` Step:**
    *   The logic to determine the version/tag was updated:
        ```yaml
        run: |
          # Triggered by workflow_run (tag creation from PR merge)
          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
            TAG_NAME=$(echo "${{ github.event.workflow_run.ref }}" | sed 's,refs/tags/,,' )
            echo "version=$TAG_NAME" >> $GITHUB_OUTPUT
          # Triggered by workflow_dispatch (manual build with specified tag)
          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
            echo "version=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
          fi
        ```
    *   **`workflow_run` Case:**
        *   `github.event.workflow_run.ref` now contains the ref (e.g., `refs/tags/v1.2.3`) from the completed workflow.
        *   `sed 's,refs/tags/,,'` extracts the tag name (e.g., `v1.2.3`).
        * it then exports the `version` to the step output
    *   **`workflow_dispatch` Case:**
        *   `github.event.inputs.tag` is used to get the user-provided tag value.
        *   It directly sets this value as the `version`.
    * Removed `if [[ "${{ github.ref }}" == "refs/tags/"* ]]; then` since we are not working directly with the tag on the branch, but with the event type instead
    * removed `else: echo "version=latest" >> $GITHUB_OUTPUT` since it no longer applies, a tag will be used in both cases.

4. **Login to Github Container Registry**
    * Removed the `if: github.event_name != 'pull_request'` as there is no longer a reason to block this. We will login in both cases.

5.  **`Docker meta` Step:**
    *  Added prefix `sha-` to the `sha` tag to make it easily identifiable.

6.  **`Build and Push Docker Image` Step:**
    *   `push: true` was changed from `push: ${{ github.event_name != 'pull_request' && steps.get_version.outputs.version != 'latest' }}`
    * Since the `get_version` step determines the version/tag, we can now always push, no matter the event type.
    * This makes it much simpler.

**How it Works Now:**

*   **Automatic Trigger (Tag Creation):**
    1.  When a PR is merged to the `main` branch, the "Create Tag on Merge to Main" workflow runs.
    2.  If it succeeds, this `002-build-and-push-gcr.yaml` workflow is automatically triggered (due to `workflow_run`).
    3.  The `build` job runs.
    4.  The `Get Version` step extracts the tag name from `github.event.workflow_run.ref`.
    5.  The image is built and pushed to GHCR with the tag extracted.
    6. the image is also pushed with its sha

*   **Manual Trigger (Workflow Dispatch):**
    1.  You go to the "Actions" tab in your GitHub repository.
    2.  You find the `002-build-and-push-gcr.yaml` workflow in the list.
    3.  You click "Run workflow" and provide a tag name in the `tag` input (e.g., `v1.2.4`).
    4.  The `build` job runs.
    5.  The `Get Version` step uses the `github.event.inputs.tag` value.
    6.  The image is built and pushed to GHCR with the tag you entered.
    7. the image is also pushed with its sha

**Key Improvements:**

*   **Manual Triggering:** You can now manually build and push images with specific tags.
*   **Clearer Version Logic:** The `Get Version` step is simplified and more robust.
*   **No more "latest":** The workflow now uses only version tags.
* **Always pushes:** pushing logic has been simplified.
* **Sha prefix:** added prefix to make the sha tags more readable.
* **login in all cases:** removed unecessary conditional login step.
* **Less Complexity:** The overall workflow is less complex.
* **Correct Version Extraction:** The tag extraction is more reliable.
* **Better Readability:** The code is easier to understand.
* **Correct indentations:** all indentations are corrected.

This revised solution addresses the original problem and significantly improves the workflow's functionality and maintainability.